### PR TITLE
Issue/18/apply

### DIFF
--- a/PowerAutomateMockUp/ExpressionParser/ExpressionEngine.cs
+++ b/PowerAutomateMockUp/ExpressionParser/ExpressionEngine.cs
@@ -3,6 +3,7 @@
     public interface IExpressionEngine
     {
         string Parse(string input);
+        ValueContainer ParseToValueContainer(string input);
     }
 
     public class ExpressionEngine : IExpressionEngine
@@ -16,7 +17,12 @@
 
         public string Parse(string input)
         {
-            return _expressionGrammar.Evaluate(input);
+            return _expressionGrammar.EvaluateToString(input);
+        }
+
+        public ValueContainer ParseToValueContainer(string input)
+        {
+            return _expressionGrammar.EvaluateToValueContainer(input);
         }
     }
 }

--- a/PowerAutomateMockUp/ExpressionParser/Functions/Base/FlowRunnerDependencyExtension.cs
+++ b/PowerAutomateMockUp/ExpressionParser/Functions/Base/FlowRunnerDependencyExtension.cs
@@ -16,7 +16,7 @@ namespace Parser.ExpressionParser.Functions.Base
             services.AddSingleton<FlowRunner>();
 
             services.AddSingleton<ActionExecutorFactory>();
-            services.AddSingleton<ScopeDepthManager>();
+            services.AddSingleton<IScopeDepthManager>();
 
             services.AddScoped<IState, State>();
             services.AddScoped<IVariableRetriever>(x => x.GetRequiredService<IState>());
@@ -28,15 +28,19 @@ namespace Parser.ExpressionParser.Functions.Base
             services.AddTransient<IFunction, ConcatFunction>();
             services.AddTransient<IFunction, ToLower>();
             services.AddTransient<IFunction, ToUpperFunction>();
+            
             services.AddTransient<IFunction, VariablesFunction>();
             services.AddTransient<IFunction, OutputsFunction>();
             services.AddTransient<IFunction, TriggerOutputsFunctions>();
+            services.AddTransient<IFunction, ItemsFunction>();
+            
             services.AddTransient<IFunction, TrimFunction>();
             services.AddTransient<IFunction, LengthFunction>();
 
             services.AddFlowActionByFlowType<IfActionExecutor>("If");
             services.AddFlowActionByFlowType<ScopeActionExecutor>("Scope");
             services.AddFlowActionByFlowType<TerminateActionExecutor>("Terminate");
+            services.AddFlowActionByFlowType<ForEachActionExecutor>("Foreach");
             
             services.AddLogging();
         }

--- a/PowerAutomateMockUp/ExpressionParser/Functions/Base/FlowRunnerDependencyExtension.cs
+++ b/PowerAutomateMockUp/ExpressionParser/Functions/Base/FlowRunnerDependencyExtension.cs
@@ -16,7 +16,7 @@ namespace Parser.ExpressionParser.Functions.Base
             services.AddSingleton<FlowRunner>();
 
             services.AddSingleton<ActionExecutorFactory>();
-            services.AddSingleton<IScopeDepthManager>();
+            services.AddSingleton<IScopeDepthManager, ScopeDepthManager>();
 
             services.AddScoped<IState, State>();
             services.AddScoped<IVariableRetriever>(x => x.GetRequiredService<IState>());

--- a/PowerAutomateMockUp/ExpressionParser/Functions/Storage/ItemsFunction.cs
+++ b/PowerAutomateMockUp/ExpressionParser/Functions/Storage/ItemsFunction.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Parser.ExpressionParser.Functions.Base;
+using Parser.ExpressionParser.Functions.CustomException;
+
+namespace Parser.ExpressionParser.Functions.Storage
+{
+    public class ItemsFunction : Function
+    {
+        private readonly IState _variableRetriever;
+
+        public ItemsFunction(IState variableRetriever) : base("items")
+        {
+            _variableRetriever = variableRetriever ?? throw new ArgumentNullException(nameof(variableRetriever));
+        }
+
+        public override ValueContainer ExecuteFunction(params ValueContainer[] parameters)
+        {
+            if (parameters.Length != 1)
+            {
+                throw new ArgumentError(parameters.Length > 1 ? "Too many arguments" : "Too few arguments");
+            }
+
+            var variableName = parameters[0].GetValue<string>();
+            // TODO: Maybe implement another storage option?
+            var value = _variableRetriever.GetOutputs($"item_{variableName}");
+
+            return value;
+        }
+    }
+}

--- a/PowerAutomateMockUp/FlowParser/ActionExecutors/IScopeActionExecutor.cs
+++ b/PowerAutomateMockUp/FlowParser/ActionExecutors/IScopeActionExecutor.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Parser.FlowParser.ActionExecutors
+{
+    public interface IScopeActionExecutor
+    {
+        public Task<ActionResult> ExitScope(ActionStatus scopeStatus);
+    }
+}

--- a/PowerAutomateMockUp/FlowParser/ActionExecutors/Implementations/ForEachActionExecutor.cs
+++ b/PowerAutomateMockUp/FlowParser/ActionExecutors/Implementations/ForEachActionExecutor.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using Parser.ExpressionParser;
+
+namespace Parser.FlowParser.ActionExecutors.Implementations
+{
+    public class ForEachActionExecutor : DefaultBaseActionExecutor, IScopeActionExecutor
+    {
+        private readonly IState _state;
+        private readonly IScopeDepthManager _scopeDepthManager;
+        private readonly ILogger<ForEachActionExecutor> _logger;
+        private readonly IExpressionEngine _expressionEngine;
+
+        private List<ValueContainer> _items;
+
+        public ForEachActionExecutor(
+            IState state,
+            IScopeDepthManager scopeDepthManager,
+            ILogger<ForEachActionExecutor> logger, 
+            IExpressionEngine expressionEngine)
+        {
+            _state = state ?? throw new ArgumentNullException(nameof(state));
+            _scopeDepthManager = scopeDepthManager ?? throw new ArgumentNullException(nameof(scopeDepthManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            _expressionEngine = expressionEngine ?? throw new ArgumentNullException(nameof(expressionEngine));
+
+            _items = new List<ValueContainer>();
+        }
+
+        public override Task<ActionResult> Execute()
+        {
+            _logger.LogInformation("Entered foreach...");
+            
+            var runOn = Json.SelectToken("$..foreach").Value<string>();
+            var temp = _expressionEngine.Parse(runOn);
+            var values = _state.GetOutputs(runOn).GetValue<List<ValueContainer>>();
+
+            var firstScopeAction = SetupScope();
+
+            // TODO: Add scope relevant storage to store stuff like this, which cannot interfere with the state.
+            _state.AddOutputs($"item_{ActionName}", values.First());
+            _items = values.Skip(1).ToList();
+
+            return Task.FromResult(new ActionResult {NextAction = firstScopeAction.Name});
+        }
+
+        private JProperty SetupScope()
+        {
+            var scopeActionDescriptions = Json.SelectToken("$.actions").OfType<JProperty>();
+            var actionDescriptions = scopeActionDescriptions as JProperty[] ?? scopeActionDescriptions.ToArray();
+
+            _scopeDepthManager.Push(ActionName, actionDescriptions, this);
+
+            var firstScopeAction = actionDescriptions.First(ad => !ad.Value.SelectToken("$.runAfter").Any());
+            return firstScopeAction;
+        }
+
+        public Task<ActionResult> ExitScope(ActionStatus scopeStatus)
+        {
+            if (_items.Count > 0)
+            {
+                _logger.LogInformation("Continuing foreach.");
+                _items = _items.Skip(1).ToList();
+
+                _state.AddOutputs($"item_{ActionName}", _items.First());
+
+                var firstScopeAction = SetupScope();
+
+                return Task.FromResult(new ActionResult {NextAction = firstScopeAction.Name});
+            }
+            else
+            {
+                _logger.LogInformation("Exited foreach...");
+                return Task.FromResult(new ActionResult());
+            }
+        }
+    }
+}

--- a/PowerAutomateMockUp/FlowParser/ActionExecutors/Implementations/ForEachActionExecutor.cs
+++ b/PowerAutomateMockUp/FlowParser/ActionExecutors/Implementations/ForEachActionExecutor.cs
@@ -15,6 +15,9 @@ namespace Parser.FlowParser.ActionExecutors.Implementations
         private readonly ILogger<ForEachActionExecutor> _logger;
         private readonly IExpressionEngine _expressionEngine;
 
+        private JProperty[] _actionDescriptions;
+        private string _firstScopeActionName;
+
         private List<ValueContainer> _items;
 
         public ForEachActionExecutor(
@@ -35,7 +38,13 @@ namespace Parser.FlowParser.ActionExecutors.Implementations
         {
             _logger.LogInformation("Entered foreach...");
 
-            var runOn = Json.SelectToken("$..foreach").Value<string>();
+            if (Json == null)
+            {
+                throw new PowerAutomateMockUpException($"Json cannot be null - cannot execute {ActionName}.");
+            }
+
+            var runOn = (Json.SelectToken("$..foreach") ??
+                         throw new InvalidOperationException("Json must contain foreach token.")).Value<string>();
             var values = _expressionEngine.ParseToValueContainer(runOn);
 
             if (values.Type() != ValueContainer.ValueType.Array)
@@ -44,28 +53,36 @@ namespace Parser.FlowParser.ActionExecutors.Implementations
                     // TODO: Figure out what happens when you apply for each on non array values
                     ActionStatus = ActionStatus.Failed
                 });
-            
-            var valueList = values.GetValue<IEnumerable<ValueContainer>>().ToArray();
-                
-            var firstScopeAction = SetupScope();
+
+            SetupForEach(values);
+
+            UpdateScopeAndSetItemValue();
+
+            return Task.FromResult(new ActionResult {NextAction = _firstScopeActionName});
+        }
+
+        private void SetupForEach(ValueContainer values)
+        {
+            var scopeActionDescriptions = (Json.SelectToken("$.actions") ??
+                                           throw new InvalidOperationException("Json must contain actions token."))
+                .OfType<JProperty>();
+            _actionDescriptions = scopeActionDescriptions as JProperty[] ?? scopeActionDescriptions.ToArray();
+            _firstScopeActionName = _actionDescriptions.First(ad =>
+                !(ad.Value.SelectToken("$.runAfter") ??
+                  throw new InvalidOperationException("Json must contain runAfter token.")).Any()).Name;
 
             // TODO: Add scope relevant storage to store stuff like this, which cannot interfere with the state.
-            _state.AddOutputs($"item_{ActionName}", valueList.First());
-            _items = valueList.Skip(1).ToList();
-
-            return Task.FromResult(new ActionResult {NextAction = firstScopeAction.Name});
+            _items = values.GetValue<IEnumerable<ValueContainer>>().ToList();
         }
 
-        private JProperty SetupScope()
+        private void UpdateScopeAndSetItemValue()
         {
-            var scopeActionDescriptions = Json.SelectToken("$.actions").OfType<JProperty>();
-            var actionDescriptions = scopeActionDescriptions as JProperty[] ?? scopeActionDescriptions.ToArray();
+            _scopeDepthManager.Push(ActionName, _actionDescriptions, this);
 
-            _scopeDepthManager.Push(ActionName, actionDescriptions, this);
-
-            var firstScopeAction = actionDescriptions.First(ad => !ad.Value.SelectToken("$.runAfter").Any());
-            return firstScopeAction;
+            _state.AddOutputs($"item_{ActionName}", _items.First());
+            _items = _items.Skip(1).ToList();
         }
+
 
         public Task<ActionResult> ExitScope(ActionStatus scopeStatus)
         {
@@ -73,13 +90,9 @@ namespace Parser.FlowParser.ActionExecutors.Implementations
             {
                 _logger.LogInformation("Continuing foreach.");
 
-                _state.AddOutputs($"item_{ActionName}", _items.First());
+                UpdateScopeAndSetItemValue();
 
-                _items = _items.Skip(1).ToList();
-                
-                var firstScopeAction = SetupScope();
-
-                return Task.FromResult(new ActionResult {NextAction = firstScopeAction.Name});
+                return Task.FromResult(new ActionResult {NextAction = _firstScopeActionName});
             }
             else
             {

--- a/PowerAutomateMockUp/FlowParser/ActionExecutors/Implementations/ScopeActionExecutor.cs
+++ b/PowerAutomateMockUp/FlowParser/ActionExecutors/Implementations/ScopeActionExecutor.cs
@@ -7,9 +7,9 @@ namespace Parser.FlowParser.ActionExecutors.Implementations
 {
     public class ScopeActionExecutor : DefaultBaseActionExecutor
     {
-        private readonly ScopeDepthManager _scopeDepthManager;
+        private readonly IScopeDepthManager _scopeDepthManager;
 
-        public ScopeActionExecutor(ScopeDepthManager scopeDepthManager)
+        public ScopeActionExecutor(IScopeDepthManager scopeDepthManager)
         {
             _scopeDepthManager = scopeDepthManager ?? throw new ArgumentNullException(nameof(scopeDepthManager));
         }
@@ -25,10 +25,5 @@ namespace Parser.FlowParser.ActionExecutors.Implementations
 
             return Task.FromResult(new ActionResult {NextAction = firstScopeAction.Name});
         }
-    }
-
-    public interface IScopeActionExecutor
-    {
-        public Task<ActionResult> ExitScope(ActionStatus scopeStatus);
     }
 }

--- a/PowerAutomateMockUp/FlowParser/ActionExecutors/OpenApiConnectionBaseActionExecutor.cs
+++ b/PowerAutomateMockUp/FlowParser/ActionExecutors/OpenApiConnectionBaseActionExecutor.cs
@@ -30,8 +30,7 @@ namespace Parser.FlowParser.ActionExecutors
             Parameters = new ValueContainer(new Dictionary<string, ValueContainer>());
             foreach (var keyValuePar in content.Parameters)
             {
-                // TODO: Here is an use case where the engine could have just returned a Value Container instead!
-                Parameters[keyValuePar.Key] = new ValueContainer(_expressionEngine.Parse(keyValuePar.Value));
+                Parameters[keyValuePar.Key] = _expressionEngine.ParseToValueContainer(keyValuePar.Value);
             }
         }
 

--- a/PowerAutomateMockUp/FlowParser/FlowRunner.cs
+++ b/PowerAutomateMockUp/FlowParser/FlowRunner.cs
@@ -15,13 +15,13 @@ namespace Parser.FlowParser
     {
         private readonly IState _state;
         private readonly FlowSettings _flowRunnerSettings;
-        private readonly ScopeDepthManager _scopeManager;
+        private readonly IScopeDepthManager _scopeManager;
         private readonly ActionExecutorFactory _actionExecutorFactory;
         private JProperty _trigger;
 
         public FlowRunner(
             IState state,
-            ScopeDepthManager scopeDepthManager,
+            IScopeDepthManager scopeDepthManager,
             IOptions<FlowSettings> flowRunnerSettings,
             ActionExecutorFactory actionExecutorFactory)
         {

--- a/PowerAutomateMockUp/IScopeDepthManager.cs
+++ b/PowerAutomateMockUp/IScopeDepthManager.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Parser.FlowParser.ActionExecutors;
+
+namespace Parser
+{
+    public interface IScopeDepthManager
+    {
+        Task<ActionResult> TryPopScope(ActionStatus scopeStatus);
+
+        void Push(
+            string scopeName,
+            IEnumerable<JProperty> scopeActionDescriptions,
+            IScopeActionExecutor scopeActionExecutor);
+
+        IEnumerable<JProperty> CurrentActionDescriptions { get; }
+    }
+}

--- a/PowerAutomateMockUp/ScopeDepthManager.cs
+++ b/PowerAutomateMockUp/ScopeDepthManager.cs
@@ -5,20 +5,19 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
 using Parser.FlowParser.ActionExecutors;
-using Parser.FlowParser.ActionExecutors.Implementations;
 
 namespace Parser
 {
-    public class ScopeDepthManager
+    public class ScopeDepthManager : IScopeDepthManager
     {
-        private readonly ILogger<ScopeDepthManager> _logger;
+        private readonly ILogger<IScopeDepthManager> _logger;
         public IEnumerable<JProperty> CurrentActionDescriptions { get; private set; }
 
         private readonly Stack<string> _scopes;
         private readonly Stack<IScopeActionExecutor> _scopeActionExecutors;
         private readonly Stack<IEnumerable<JProperty>> _actionDescriptions;
 
-        public ScopeDepthManager(ILogger<ScopeDepthManager> logger)
+        public ScopeDepthManager(ILogger<IScopeDepthManager> logger)
         {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _actionDescriptions = new Stack<IEnumerable<JProperty>>();

--- a/Test/ActionTests/ForEachActionExecutorTest.cs
+++ b/Test/ActionTests/ForEachActionExecutorTest.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Parser;
+using Parser.ExpressionParser;
+using Parser.FlowParser.ActionExecutors;
+using Parser.FlowParser.ActionExecutors.Implementations;
+
+namespace Test.ActionTests
+{
+    [TestFixture]
+    public class ForEachActionExecutorTest
+    {
+        private const string ForEachAction =
+            "{" +
+            "\"foreach\":\"@outputs('List_records')?['body/value']\"," +
+            "\"actions\":{" +
+            "\"Update_a_record\":{" +
+            "\"runAfter\":{}," +
+            "\"type\":\"OpenApiConnection\"," +
+            "\"inputs\":{" +
+            "\"host\":{" +
+            "\"connectionName\":\"shared_commondataserviceforapps\"," +
+            "\"operationId\":\"UpdateRecord\"," +
+            "\"apiId\":\"/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps\"" +
+            "}," +
+            "\"parameters\":{" +
+            "\"entityName\":\"accounts\"," +
+            "\"recordId\":\"@items('Apply_to_each')?['accountid']\"" +
+            "}," +
+            "\"authentication\":{" +
+            "\"type\":\"Raw\"," +
+            "\"value\":\"@json(decodeBase64(triggerOutputs().headers['X-MS-APIM-Tokens']))['$ConnectionKey']\"" +
+            "}" +
+            "}" +
+            "}" +
+            "}," +
+            "\"runAfter\":{" +
+            "\"List_records\":[" +
+            "\"Succeeded\"" +
+            "]" +
+            "}," +
+            "\"type\":\"Foreach\"" +
+            "}";
+
+        [TestCase]
+        public async Task Test()
+        {
+            var loggerMock = TestLogger.Create<ForEachActionExecutor>();
+
+            var initialList = new ValueContainer(new[]
+            {
+                new ValueContainer(new Dictionary<string, ValueContainer>
+                {
+                    {"item1", new ValueContainer("Value1")}
+                }),
+                new ValueContainer(new Dictionary<string, ValueContainer>
+                {
+                    {"item2", new ValueContainer("Value2")}
+                }),
+                new ValueContainer(new Dictionary<string, ValueContainer>
+                {
+                    {"item3", new ValueContainer("Value3")}
+                }),
+            });
+
+            var stateMock = new Mock<IState>();
+
+            stateMock.Setup(x => x.GetOutputs("")).Returns(initialList);
+
+            var sdmMock = new Mock<IScopeDepthManager>();
+
+
+            var forEachActionExecutor = new ForEachActionExecutor(stateMock.Object, sdmMock.Object, loggerMock);
+            forEachActionExecutor.InitializeActionExecutor("Foreach", JToken.Parse(ForEachAction));
+
+            var response = await forEachActionExecutor.Execute();
+
+            Assert.AreEqual("Update_a_record", response.NextAction);
+
+            stateMock.Verify(x => x.AddOutputs(It.IsAny<string>(), It.IsAny<ValueContainer>()), Times.Exactly(1));
+            sdmMock.Verify(x => x.Push(It.IsAny<string>(), It.IsAny<IEnumerable<JProperty>>(),
+                It.Is<ForEachActionExecutor>(actionExecutor => 
+                    actionExecutor.Equals(forEachActionExecutor))), Times.Exactly(1));
+
+            var exitAnswer1 = await forEachActionExecutor.ExitScope(ActionStatus.Succeeded);
+            Assert.AreEqual("Update_a_record", exitAnswer1.NextAction);
+
+            stateMock.Verify(x => x.AddOutputs(It.IsAny<string>(), It.IsAny<ValueContainer>()), Times.Exactly(2));
+
+            var exitAnswer2 = await forEachActionExecutor.ExitScope(ActionStatus.Succeeded);
+            sdmMock.Verify(x => x.Push(It.IsAny<string>(), It.IsAny<IEnumerable<JProperty>>(),
+                It.Is<ForEachActionExecutor>(actionExecutor => 
+                    actionExecutor.Equals(forEachActionExecutor))), Times.Exactly(2));
+            
+            Assert.AreEqual("Update_a_record", exitAnswer2.NextAction);
+
+            stateMock.Verify(x => x.AddOutputs(It.IsAny<string>(), It.IsAny<ValueContainer>()), Times.Exactly(3));
+            sdmMock.Verify(x => x.Push(It.IsAny<string>(), It.IsAny<IEnumerable<JProperty>>(),
+                It.Is<ForEachActionExecutor>(actionExecutor => 
+                    actionExecutor.Equals(forEachActionExecutor))), Times.Exactly(3));
+            
+            var exitAnswer3 = await forEachActionExecutor.ExitScope(ActionStatus.Succeeded);
+            Assert.AreEqual(null, exitAnswer3.NextAction);
+        }
+    }
+}

--- a/Test/ActionTests/IfActionTest.cs
+++ b/Test/ActionTests/IfActionTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;

--- a/Test/ActionTests/ScopeActionExecutorTest.cs
+++ b/Test/ActionTests/ScopeActionExecutorTest.cs
@@ -5,7 +5,6 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using Parser;
 using Parser.FlowParser.ActionExecutors;
-using Parser.FlowParser.ActionExecutors.Implementations;
 
 namespace Test.ActionTests
 {
@@ -15,7 +14,7 @@ namespace Test.ActionTests
         [Test]
         public async Task TestBasicScopeUseCase()
         {
-            var logger = TestLogger.Create<ScopeDepthManager>();
+            var logger = TestLogger.Create<IScopeDepthManager>();
 
             var scopeDepthManager = new ScopeDepthManager(logger);
             scopeDepthManager.Push("rootScope", new List<JProperty>(), null);

--- a/Test/FlowSamples/PAMUApplyToEach.json
+++ b/Test/FlowSamples/PAMUApplyToEach.json
@@ -1,0 +1,96 @@
+﻿{
+  "name": "3153d4d3-ea76-4bf8-9fd0-20dba68dd98f",
+  "id": "/providers/Microsoft.Flow/flows/3153d4d3-ea76-4bf8-9fd0-20dba68dd98f",
+  "type": "Microsoft.Flow/flows",
+  "properties": {
+    "apiId": "/providers/Microsoft.PowerApps/apis/shared_logicflows",
+    "displayName": "Button -> List records,Apply to each,Update a record",
+    "definition": {
+      "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+      "contentVersion": "1.0.0.0",
+      "parameters": {
+        "$connections": {
+          "defaultValue": {},
+          "type": "Object"
+        },
+        "$authentication": {
+          "defaultValue": {},
+          "type": "SecureObject"
+        }
+      },
+      "triggers": {
+        "manual": {
+          "type": "Request",
+          "kind": "Button",
+          "inputs": {
+            "schema": {
+              "type": "object",
+              "properties": {},
+              "required": []
+            }
+          }
+        }
+      },
+      "actions": {
+        "List_records": {
+          "runAfter": {},
+          "type": "OpenApiConnection",
+          "inputs": {
+            "host": {
+              "connectionName": "shared_commondataserviceforapps",
+              "operationId": "ListRecords",
+              "apiId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps"
+            },
+            "parameters": {
+              "entityName": "accounts",
+              "$filter": "contains(name, 'Test')"
+            },
+            "authentication": {
+              "type": "Raw",
+              "value": "@json(decodeBase64(triggerOutputs().headers['X-MS-APIM-Tokens']))['$ConnectionKey']"
+            }
+          }
+        },
+        "Apply_to_each": {
+          "foreach": "@outputs('List_records')?['body/value']",
+          "actions": {
+            "Update_a_record": {
+              "runAfter": {},
+              "type": "OpenApiConnection",
+              "inputs": {
+                "host": {
+                  "connectionName": "shared_commondataserviceforapps",
+                  "operationId": "UpdateRecord",
+                  "apiId": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps"
+                },
+                "parameters": {
+                  "entityName": "accounts",
+                  "recordId": "@items('Apply_to_each')?['accountid']"
+                },
+                "authentication": {
+                  "type": "Raw",
+                  "value": "@json(decodeBase64(triggerOutputs().headers['X-MS-APIM-Tokens']))['$ConnectionKey']"
+                }
+              }
+            }
+          },
+          "runAfter": {
+            "List_records": [
+              "Succeeded"
+            ]
+          },
+          "type": "Foreach"
+        }
+      },
+      "outputs": {}
+    },
+    "connectionReferences": {
+      "shared_commondataserviceforapps": {
+        "source": "Embedded",
+        "id": "/providers/Microsoft.PowerApps/apis/shared_commondataserviceforapps",
+        "tier": "NotSpecified"
+      }
+    },
+    "flowFailureAlertSubscribed": false
+  }
+}

--- a/Test/PAMUApplyToEachTest.cs
+++ b/Test/PAMUApplyToEachTest.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Parser;
+using Parser.ExpressionParser;
+using Parser.ExpressionParser.Functions.Base;
+using Parser.FlowParser;
+using Parser.FlowParser.ActionExecutors;
+
+namespace Test
+{
+    [TestFixture]
+    public class PAMUApplyToEachTest
+    {
+        private static readonly string TestFlowPath = System.IO.Path.GetFullPath(@"FlowSamples");
+
+        [Test]
+        public async Task TestForEachFlow()
+        {
+            var path = @$"{TestFlowPath}\PAMUApplyToEach.json";
+
+            var services = new ServiceCollection();
+
+            services.Configure<FlowSettings>(x => x.FailOnUnknownAction = true);
+
+            services.AddFlowActionByName<ManualTrigger>(ManualTrigger.TriggerName);
+            services.AddFlowActionByName<ListRecordsAccounts>(ListRecordsAccounts.FlowActionName);
+            services.AddFlowActionByName<UpdateRecord>(UpdateRecord.FlowActionName);
+
+            services.AddFlowRunner();
+
+            var sp = services.BuildServiceProvider();
+            var flowRunner = sp.GetRequiredService<FlowRunner>();
+
+            flowRunner.InitializeFlowRunner(path);
+
+            await flowRunner.Trigger();
+
+            var state = sp.GetRequiredService<IState>();
+
+            /*
+            Assert.IsTrue(state.GetOutputs("SecondOutput").Type() != ValueContainer.ValueType.Null);
+            Assert.IsTrue(state.GetOutputs("ThirdOutput").Type() != ValueContainer.ValueType.Null);
+            Assert.IsTrue(state.GetOutputs("FourthOutput").Type() == ValueContainer.ValueType.Null);
+
+            Assert.IsTrue(state.GetOutputs("SecondOutput").GetValue<bool>(), "Second action wasn't triggered");
+            Assert.IsTrue(state.GetOutputs("ThirdOutput").GetValue<bool>(), "Third action wasn't triggered");
+        */
+        }
+
+        private class ManualTrigger : DefaultBaseActionExecutor
+        {
+            public const string TriggerName = "manual";
+
+            public override Task<ActionResult> Execute()
+            {
+                return Task.FromResult(new ActionResult());
+            }
+        }
+
+        private class ListRecordsAccounts : OpenApiConnectionActionExecutorBase
+        {
+            private readonly IState _state;
+            public const string FlowActionName = "List_records";
+
+            public static readonly Guid[] Guids = {Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()};
+
+            public override Task<ActionResult> Execute()
+            {
+                var accountList = new ValueContainer(new[]
+                {
+                    new ValueContainer(
+                        new Dictionary<string, ValueContainer>
+                        {
+                            {"accountid", new ValueContainer(Guids[0].ToString())}
+                        }),
+                    new ValueContainer(
+                        new Dictionary<string, ValueContainer>
+                        {
+                            {"accountid", new ValueContainer(Guids[1].ToString())}
+                        }),
+                    new ValueContainer(
+                        new Dictionary<string, ValueContainer>
+                        {
+                            {"accountid", new ValueContainer(Guids[2].ToString())}
+                        })
+                });
+
+                _state.AddOutputs("List_records", new ValueContainer(new Dictionary<string, ValueContainer>
+                {
+                    {"body/value", accountList}
+                }));
+
+
+                return Task.FromResult(new ActionResult {ActionStatus = ActionStatus.Succeeded});
+            }
+
+            public ListRecordsAccounts(IExpressionEngine expressionEngine, IState state) : base(expressionEngine)
+            {
+                _state = state ?? throw new ArgumentNullException(nameof(state));
+            }
+        }
+
+
+        private class UpdateRecord : OpenApiConnectionActionExecutorBase
+        {
+            private readonly IState _state;
+            public const string FlowActionName = "Update_a_record";
+            private static readonly List<string> ProcessedGuids = new List<string>();
+
+            public UpdateRecord(IExpressionEngine expressionEngine, IState state) : base(expressionEngine)
+            {
+                _state = state ?? throw new ArgumentNullException(nameof(state));
+            }
+
+            public override Task<ActionResult> Execute()
+            {
+                var paras = Parameters;
+
+                var recordId = paras["recordId"].GetValue<string>();
+                Assert.IsTrue(
+                    ListRecordsAccounts.Guids.Any(x => x.ToString().Equals(recordId)),
+                    "Record ID from flow action parameters does not match expected.");
+
+                Assert.IsTrue(
+                    !ProcessedGuids.Any(x => x.ToString().Equals(recordId)),
+                    "Record ID from flow action parameters is already processed.");
+                
+                ProcessedGuids.Add(recordId);
+                
+                return Task.FromResult(new ActionResult());
+            }
+        }
+    }
+}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -34,6 +34,9 @@
         <None Update="FlowSamples\Pure CDS ce.json">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="FlowSamples\PAMUApplyToEach.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added support for the apply for each action.

When a for each is meet, the actions inside is threated as a scope, and the for each scope handler have logic when the flow exists the scope.

The exit logic checks if all the items in the array have been processed, and if not, the next item is made ready to be accessed via the `items` expression and the scope is pushed again, and the first action of the actions is set as the next action to be executed.

When all the items have been processed, the scope is exited properly and the execution continues.