### PR TITLE
refactor: Refactored the way Output is handled.

### DIFF
--- a/PowerAutomateMockUp/FlowParser/ActionExecutors/ActionResult.cs
+++ b/PowerAutomateMockUp/FlowParser/ActionExecutors/ActionResult.cs
@@ -1,4 +1,6 @@
-﻿namespace Parser.FlowParser.ActionExecutors
+﻿using Parser.ExpressionParser;
+
+namespace Parser.FlowParser.ActionExecutors
 {
     /// <summary>
     /// An ActionResult contains updated/retrieved variables, as well as
@@ -17,7 +19,18 @@
         /// </summary>
         public ActionStatus ActionStatus { get; set; } = ActionStatus.Succeeded;
 
+        /// <summary>
+        /// If for some reason you want to stop the execution, this can
+        /// be set to false
+        /// </summary>
         public bool ContinueExecution { get; set; } = true;
+        
+        /// <summary>
+        /// When and if an action is done and the output have been produced,
+        /// the output is returned to the flow runner using the ActionResult object and
+        /// the output is added correctly to the state.
+        /// </summary>
+        public ValueContainer ActionOutput { get; set; }
     }
 
     public enum ActionStatus

--- a/Test/PAMUApplyToEachTest.cs
+++ b/Test/PAMUApplyToEachTest.cs
@@ -63,7 +63,6 @@ namespace Test
 
         private class ListRecordsAccounts : OpenApiConnectionActionExecutorBase
         {
-            private readonly IState _state;
             public const string FlowActionName = "List_records";
 
             public static readonly Guid[] Guids = {Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()};
@@ -89,31 +88,29 @@ namespace Test
                         })
                 });
 
-                _state.AddOutputs("List_records", new ValueContainer(new Dictionary<string, ValueContainer>
+                return Task.FromResult(new ActionResult
                 {
-                    {"body/value", accountList}
-                }));
-
-
-                return Task.FromResult(new ActionResult {ActionStatus = ActionStatus.Succeeded});
+                    ActionStatus = ActionStatus.Succeeded, ActionOutput = new ValueContainer(
+                        new Dictionary<string, ValueContainer>
+                        {
+                            {"body/value", accountList}
+                        })
+                });
             }
 
-            public ListRecordsAccounts(IExpressionEngine expressionEngine, IState state) : base(expressionEngine)
+            public ListRecordsAccounts(IExpressionEngine expressionEngine) : base(expressionEngine)
             {
-                _state = state ?? throw new ArgumentNullException(nameof(state));
             }
         }
 
 
         private class UpdateRecord : OpenApiConnectionActionExecutorBase
         {
-            private readonly IState _state;
             public const string FlowActionName = "Update_a_record";
             private static readonly List<string> ProcessedGuids = new List<string>();
 
-            public UpdateRecord(IExpressionEngine expressionEngine, IState state) : base(expressionEngine)
+            public UpdateRecord(IExpressionEngine expressionEngine) : base(expressionEngine)
             {
-                _state = state ?? throw new ArgumentNullException(nameof(state));
             }
 
             public override Task<ActionResult> Execute()
@@ -128,9 +125,9 @@ namespace Test
                 Assert.IsTrue(
                     !ProcessedGuids.Any(x => x.ToString().Equals(recordId)),
                     "Record ID from flow action parameters is already processed.");
-                
+
                 ProcessedGuids.Add(recordId);
-                
+
                 return Task.FromResult(new ActionResult());
             }
         }

--- a/Test/PAMUSwitchTest.cs
+++ b/Test/PAMUSwitchTest.cs
@@ -52,7 +52,6 @@ namespace Test
 
         private class ListRecordsAccounts : OpenApiConnectionActionExecutorBase
         {
-            private readonly IState _state;
             public const string FlowActionName = "List_records";
 
             public static readonly Guid[] Guids = {Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()};
@@ -69,31 +68,29 @@ namespace Test
                         })
                 });
 
-                _state.AddOutputs("List_records", new ValueContainer(new Dictionary<string, ValueContainer>
+                return Task.FromResult(new ActionResult
                 {
-                    {"body/value", accountList}
-                }));
-
-
-                return Task.FromResult(new ActionResult {ActionStatus = ActionStatus.Succeeded});
+                    ActionStatus = ActionStatus.Succeeded, ActionOutput = new ValueContainer(
+                        new Dictionary<string, ValueContainer>
+                        {
+                            {"body/value", accountList}
+                        })
+                });
             }
 
-            public ListRecordsAccounts(IExpressionEngine expressionEngine, IState state) : base(expressionEngine)
+            public ListRecordsAccounts(IExpressionEngine expressionEngine) : base(expressionEngine)
             {
-                _state = state ?? throw new ArgumentNullException(nameof(state));
             }
         }
 
 
         private class UpdateRecord : OpenApiConnectionActionExecutorBase
         {
-            private readonly IState _state;
             public const string FlowActionName = "Update_a_record";
             private static readonly List<string> ProcessedGuids = new List<string>();
 
-            public UpdateRecord(IExpressionEngine expressionEngine, IState state) : base(expressionEngine)
+            public UpdateRecord(IExpressionEngine expressionEngine) : base(expressionEngine)
             {
-                _state = state ?? throw new ArgumentNullException(nameof(state));
             }
 
             public override Task<ActionResult> Execute()


### PR DESCRIPTION
Instead of putting the responsibility in the action executor mock implementer, to add action generated values correctly, instead just have to give the generated output to the ActionResult and the flow runner handles the rest. This simplifies development of mocks and makes action executors more simple. There should be no need at all, to depend on any state related dependencies, they should all automatically be resolved before execution and after, by itself.